### PR TITLE
Investigar error 404 al acceder a menu

### DIFF
--- a/src/main/resources/templates/html/fragments/header.html
+++ b/src/main/resources/templates/html/fragments/header.html
@@ -40,7 +40,7 @@
               </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" th:href="@{/menu}"
+              <a class="nav-link" th:href="@{/productos/menu}"
                 ><svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="16px"


### PR DESCRIPTION
Update menu link in header to correctly map to the `/productos/menu` endpoint.

Previously, the link pointed to `/menu`, causing a 404 error because the `ProductoController`'s `@RequestMapping("/productos")` prefix meant the actual endpoint was `/productos/menu`.

---

[Open in Web](https://cursor.com/agents?id=bc-2b00d5b3-361a-4c7f-8382-695849293800) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2b00d5b3-361a-4c7f-8382-695849293800) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)