### PR TITLE
Corregir error de escape en lista producto

### DIFF
--- a/src/main/resources/templates/productos_menu/lista_producto.html
+++ b/src/main/resources/templates/productos_menu/lista_producto.html
@@ -131,13 +131,13 @@
                       <td>
                         <button
                           class="btn btn-sm btn-primary me-1"
-                          th:onclick="'editarProducto(' + ${producto.id} + ', \'' + ${#strings.replace(producto.nombre, '\'', '\\\'')} + '\', \'' + ${#strings.replace(producto.descripcion, '\'', '\\\'')} + '\', \'' + ${producto.tipo} + '\', ' + ${producto.precio} + ', \'' + ${#strings.replace(producto.imagenUrl, '\'', '\\\'')} + '\')'"
+                          th:attr="onclick='editarProducto(' + ${producto.id} + ', \'' + ${#strings.replace(producto.nombre, '\'', '\\\'')} + '\', \'' + ${#strings.replace(producto.descripcion, '\'', '\\\'')} + '\', \'' + ${producto.tipo} + '\', ' + ${producto.precio} + ', \'' + ${#strings.replace(producto.imagenUrl, '\'', '\\\'')} + '\')'"
                         >
                           <i class="fas fa-edit"></i>
                         </button>
                         <button
                           class="btn btn-sm btn-danger"
-                          th:onclick="'confirmarEliminar(' + ${producto.id} + ', \'' + ${#strings.replace(producto.nombre, '\'', '\\\'')} + '\')'"
+                          th:attr="onclick='confirmarEliminar(' + ${producto.id} + ', \'' + ${#strings.replace(producto.nombre, '\'', '\\\'')} + '\')'"
                         >
                           <i class="fas fa-trash"></i>
                         </button>


### PR DESCRIPTION
Refactor `th:onclick` to `th:attr` in `lista_producto.html` to resolve SpringEL parsing errors with escaped characters.

The previous `th:onclick` syntax led to `EL1065E: Unexpected escape character` when attempting to escape single quotes within the SpringEL `#strings.replace()` function, as the expression itself was already enclosed in single quotes. Switching to `th:attr` provides a more robust mechanism for handling complex dynamic attributes and nested string escaping in Thymeleaf.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c23d4ab-a75d-444b-99a6-4c59c20bbd86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c23d4ab-a75d-444b-99a6-4c59c20bbd86">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>